### PR TITLE
Deactivated users login testing on non OAuth.

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -23,6 +23,7 @@ passport.deserializeUser(function (id, done) {
 /**
  * Sign in using Email and Password.
  */
+
 passport.use(new LocalStrategy({
     usernameField: 'email'
 }, function (email, password, done) {
@@ -34,6 +35,13 @@ passport.use(new LocalStrategy({
                 msg: 'Email ' + email + ' not found.'
             });
         }
+
+        if (user.inactive) {
+            return done(null, false, {
+                msg: 'User ' + email + ' has been marked inactive.'
+            });
+        }
+
         user.comparePassword(password, function (err, isMatch) {
             if (isMatch) {
                 return done(null, user);

--- a/test/controllers/user.spec.js
+++ b/test/controllers/user.spec.js
@@ -40,7 +40,7 @@ before(function (done) {
                 password: activeUser.password
             });
             user.save(function (err) {
-                tmpActiveUser.save(function(err) {
+                tmpActiveUser.save(function (err) {
                     done(err);
                 });
             });
@@ -50,12 +50,12 @@ before(function (done) {
 
 //Remove all users when done.
 after(function (done) {
-    User.remove({}, function(err) {
+    User.remove({}, function (err) {
         done(err);
     });
 });
 
-describe('Deactivation testing', function() {
+describe('Deactivation testing', function () {
 
     it('should login admin user', function (done) {
         api.post('/login').send(tmpAdminUser).end(function (err, res) {
@@ -77,6 +77,14 @@ describe('Deactivation testing', function() {
             (user.inactive).should.equal(true);
             done(err);
         });
+    });
+
+    it('ensures deactivated user cannot login', function (done) {
+        api.post('/login').send(activeUser).end(function (err, res) {
+            (res.text).should.contain('login');
+            done(err);
+        });
+
     });
 
 });
@@ -355,4 +363,5 @@ describe('Delegation testing', function () {
             });
         });
     });
+
 });


### PR DESCRIPTION
Added testing for the basic login endpoint. I looked into the OAuth testing, basically there isn't a great way to automate the testing. You would either need to a) automate some way to allow the delegation on google's site, b) manually log in and run the tests (which I'm not entirely sure how you can get the session ID to the headless browser), or c) mock the OAuth endpoint and run it. I think the best we can hope for realistically hope for is to modularize parts of the strategy and write test cases for them, and share them between the auth models (someday). I manually tested the inactive flag and it seems to work for me.  If you roll in this PR, I'll approve your PR and we can finish this for now.